### PR TITLE
Fix: generator to work with built templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@social-native/snpkg-knex-migration-generator",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@social-native/snpkg-knex-migration-generator",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -40,7 +40,7 @@ export default async <Fn extends (...params: any[]) => MigrationGenerator>(
     const libMigrationDir = path.resolve(absPathOfLibMigrations);
 
     // regex to match filename irrespective of extension
-    const libMigrationFileName = /(.*).(ts|js)/;
+    const libMigrationFileName = /(.*).[^\.d].(ts|js)/;
     const libMigrationFiles = fs.readdirSync(libMigrationDir);
 
     // figure out which lib migrations haven't been added yet
@@ -69,7 +69,7 @@ export default async <Fn extends (...params: any[]) => MigrationGenerator>(
 
         // import the lib migration file
         const libMigrationFilePath = path.resolve(libMigrationDir, fileName);
-        const migrationFile = _migrationFnExtractor(require(libMigrationFilePath).default);
+        const migrationFile = _migrationFnExtractor(require(libMigrationFilePath));
 
         const migrationFileExtension = knex.migrate.config.extension;
         if (migrationFileExtension !== 'js' && migrationFileExtension !== 'ts') {
@@ -77,6 +77,7 @@ export default async <Fn extends (...params: any[]) => MigrationGenerator>(
                 `Migration file extension calculated to be ${migrationFileExtension}. It must be either 'js' or 'ts'`
             );
         }
+
         const migrationText = migrationFile(knex.migrate.config.extension);
 
         console.log(`Writing migration to: ${newMigrationFileNamePath}`); // tslint:disable-line


### PR DESCRIPTION
Templates need to be `built` into the dist by the packages that consume this lib. This fixes a bug where the generator was expecting something different....